### PR TITLE
Fix messages and prompts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-export DOTFILES_DIR ?= ${HOME}/.dotfiles
+export DOTFILES_ROOT ?= ${HOME}/.dotfiles
 
 zsh-reload:
 	@zsh -l
@@ -14,12 +14,12 @@ help: Makefile
 ## unset: remove variables from terminal session `source <(make unset)`
 .PHONY: unset
 unset:
-	@echo 'unset DOTFILES_DIR'
+	@echo 'unset DOTFILES_ROOT'
 
 ## env: print required variables
 .PHONY: env
 env:
-	@echo 'export DOTFILES_DIR=${DOTFILES_DIR}'
+	@echo 'export DOTFILES_ROOT=${DOTFILES_ROOT}'
 
 ## setup: Install all dependencies
 .PHONY: setup
@@ -30,11 +30,11 @@ setup-no-reload:
 	@sudo mkdir -p /usr/local/bin   # dotfiles bin-path add links inside /usr/local/bin and this folder may not exists in new versions of mac.
 	@sudo chmod 755 /usr/local/bin  # dotfiles bin-path add links inside /usr/local/bin and this folder may not exists in new versions of mac.
 	@sudo chown -R ${USER} /usr/local/bin  # dotfiles bin-path add links inside /usr/local/bin and this folder may not exists in new versions of mac.
-	@cd ${DOTFILES_DIR}/bin && ./dotfiles bin-path
-	@cd ${DOTFILES_DIR}/bin && ./dotfiles symlink
-	@cd ${DOTFILES_DIR}/bin && ./dotfiles git-setup
-	@cd ${DOTFILES_DIR}/bin && ./dotfiles install
+	@cd ${DOTFILES_ROOT}/bin && ./dotfiles bin-path
+	@cd ${DOTFILES_ROOT}/bin && ./dotfiles symlink
+	@cd ${DOTFILES_ROOT}/bin && ./dotfiles git-setup
+	@cd ${DOTFILES_ROOT}/bin && ./dotfiles install
 
 .PHONY: update
 update:
-	@cd ${DOTFILES_DIR}/bin && ./dotfiles update
+	@cd ${DOTFILES_ROOT}/bin && ./dotfiles update

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ dotfiles uninstall-plugin my-awesome-plugin
 - `dotfiles install-plugin [-nh] <DOTFILES_GIT_URL>`: Install desired plugins
   - `-h, --help`          Display help
   - `-n, --no-reload`     The installer will not refresh the session at the end
+- `dotfiles git-setup`: Create the .gitconfig and .gitconfig.local files. Use the DOTFILES_GIT_AUTHORNAME and DOTFILES_GIT_AUTHOREMAIL environment variables to use it non interactive.
 - `dotfiles update-plugin <PLUGIN_NAME>`: Update a given plugin
 - `dotfiles uninstall-plugin <PLUGIN_NAME>`: Uninstall a given plugin
 - `dotfiles create-plugin <PLUGIN_NAME>`: Create a plugin using the base template

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ dotfiles uninstall-plugin my-awesome-plugin
 
 ## Usage reference
 
-- `dotfiles install`: Install all required software
+- `dotfiles install`: Install all required software. To avoid software installation use the DOTFILES_OS_UPDATE_OS envvar set to "false".
 - `dotfiles install-plugin [-nh] <DOTFILES_GIT_URL>`: Install desired plugins
   - `-h, --help`          Display help
   - `-n, --no-reload`     The installer will not refresh the session at the end

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -12,6 +12,19 @@ function set_dotfiles_root() {
     echo $DOTFILES_ROOT
 }
 
+# This functions set up the dotfiles flag to update operative system
+# By default is disabled
+function set_dotfiles_os_update_os() {
+    if [ -z ${DOTFILES_OS_UPDATE_OS+x} ]; then
+        DOTFILES_OS_UPDATE_OS=true
+    else
+        DOTFILES_OS_UPDATE_OS="${DOTFILES_OS_UPDATE_OS%/}"
+    fi
+
+    echo $DOTFILES_OS_UPDATE_OS
+}
+
+
 # This functions set up the dotfiles verbose output
 # By default is disabled
 function set_dotfiles_debug() {
@@ -64,6 +77,7 @@ function readlink_f() {
 
 DOTFILES_ROOT=$(set_dotfiles_root)
 DOTFILES_DEBUG=$(set_dotfiles_debug)
+DOTFILES_OS_UPDATE_OS=$(set_dotfiles_os_update_os)
 
 add_dotfiles_internal_libraries_to_path $DOTFILES_ROOT
 
@@ -89,6 +103,6 @@ case "${command}" in
             }
         fi
         shift 1
-        exec "${command_path}" "$DOTFILES_ROOT" $DOTFILES_DEBUG "$@"
+        exec "${command_path}" "$DOTFILES_ROOT" $DOTFILES_DEBUG $DOTFILES_OS_UPDATE_OS "$@"
         ;;
 esac

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -103,6 +103,9 @@ case "${command}" in
             }
         fi
         shift 1
-        exec "${command_path}" "$DOTFILES_ROOT" $DOTFILES_DEBUG $DOTFILES_OS_UPDATE_OS "$@"
+        DOTFILES_OS_UPDATE_OS=$DOTFILES_OS_UPDATE_OS \
+        DOTFILES_GIT_AUTHORNAME=$DOTFILES_GIT_AUTHORNAME \
+        DOTFILES_GIT_AUTHOREMAIL=$DOTFILES_GIT_AUTHOREMAIL \
+                exec "${command_path}" "$DOTFILES_ROOT" $DOTFILES_DEBUG  "$@"
         ;;
 esac

--- a/installer
+++ b/installer
@@ -21,7 +21,7 @@ fi
 
 # Cloning repository to local final directory
 git clone https://github.com/autentia/dotfiles.git "$DOTFILES_PATH"
-git checkout fix-messages-and-prompts
+cd $DOTFILES_PATH && git checkout fix-messages-and-prompts && cd -
 
 if [ $? -ne 0 ]; then
     echo "Error trying to download dotfiles."

--- a/installer
+++ b/installer
@@ -21,6 +21,8 @@ fi
 
 # Cloning repository to local final directory
 git clone https://github.com/autentia/dotfiles.git "$DOTFILES_PATH"
+git checkout fix-messages-and-prompts
+
 if [ $? -ne 0 ]; then
     echo "Error trying to download dotfiles."
 fi

--- a/installer
+++ b/installer
@@ -19,14 +19,10 @@ if [ -d $DOTFILES_PATH ]; then
     exit 0
 fi
 
-set -x
-
 # Cloning repository to local final directory
 git clone https://github.com/autentia/dotfiles.git "$DOTFILES_PATH"
 cd $DOTFILES_PATH && git checkout fix-messages-and-prompts && cd -
 
-
-set +x
 
 if [ $? -ne 0 ]; then
     echo "Error trying to download dotfiles."
@@ -36,4 +32,4 @@ fi
 make -f $DOTFILES_PATH/Makefile setup
 
 # Reload environment
-zsh -l
+# zsh -l

--- a/installer
+++ b/installer
@@ -19,9 +19,14 @@ if [ -d $DOTFILES_PATH ]; then
     exit 0
 fi
 
+set -x
+
 # Cloning repository to local final directory
 git clone https://github.com/autentia/dotfiles.git "$DOTFILES_PATH"
 cd $DOTFILES_PATH && git checkout fix-messages-and-prompts && cd -
+
+
+set +x
 
 if [ $? -ne 0 ]; then
     echo "Error trying to download dotfiles."

--- a/lib/dotfiles-apply
+++ b/lib/dotfiles-apply
@@ -16,8 +16,8 @@ source "${DOTFILES_ROOT}/lib/helpers"
 
 debug_msg "Reloading the dotfiles"
 
-dotfiles-symlink $DOTFILES_ROOT
-dotfiles-install $DOTFILES_ROOT
-dotfiles-bin-path $DOTFILES_ROOT
+dotfiles-symlink $DOTFILES_ROOT $DOTFILES_DEBUG
+dotfiles-install $DOTFILES_ROOT $DOTFILES_DEBUG
+dotfiles-bin-path $DOTFILES_ROOT $DOTFILES_DEBUG
 
 success_msg "Dotfiles reloaded"

--- a/lib/dotfiles-git-setup
+++ b/lib/dotfiles-git-setup
@@ -5,6 +5,8 @@ IFS=$'\n\t'
 
 DOTFILES_ROOT=$1
 DOTFILES_DEBUG=$2
+DOTFILES_GIT_AUTHORNAME=${DOTFILES_GIT_AUTHORNAME:-}
+DOTFILES_GIT_AUTHOREMAIL=${DOTFILES_GIT_AUTHOREMAIL:-}
 
 # Needs to load the helpers before using it
 source "${DOTFILES_ROOT}/lib/helpers"
@@ -22,7 +24,6 @@ setup_gitconfig () {
     then
         info_msg 'setup gitconfig'
 
-
         debug_msg "[$script_file] Define git_credentials"
         git_credential='cache'
         if [ "$(uname -s)" == "Darwin" ]
@@ -31,9 +32,17 @@ setup_gitconfig () {
         fi
 
         info_msg ' - What is your git author name?'
-        read -e git_authorname
+        if [[ -z $DOTFILES_GIT_AUTHORNAME ]]; then
+          read -e git_authorname
+        else
+          git_authorname=$DOTFILES_GIT_AUTHORNAME
+        fi
         info_msg ' - What is your git author email?'
-        read -e git_authoremail
+        if [[ -z $DOTFILES_GIT_AUTHOREMAIL ]]; then
+          read -e git_authoremail
+        else
+          git_authoremail=$DOTFILES_GIT_AUTHOREMAIL
+        fi
 
         debug_msg "[$script_file] Replace values from the template to the original git config"
         sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" $git_config_path_template > $git_config_path

--- a/lib/dotfiles-install
+++ b/lib/dotfiles-install
@@ -9,7 +9,7 @@ IFS=$'\n\t'
 
 DOTFILES_ROOT=$1
 DOTFILES_DEBUG=${2:-false}
-DOTFILES_OS_UPDATE_OS=${3:-false}
+DOTFILES_OS_UPDATE_OS=${DOTFILES_OS_UPDATE_OS:-false}
 PLUGINS_DIR=$DOTFILES_ROOT/plugins
 
 # Needs to load the helpers before using it

--- a/lib/dotfiles-install
+++ b/lib/dotfiles-install
@@ -8,12 +8,12 @@ IFS=$'\n\t'
 # Search for all install.sh inside DOTFILES_ROOT and execute it
 
 DOTFILES_ROOT=$1
-DOTFILES_DEBUG=$2
+DOTFILES_DEBUG=${2:-false}
+DOTFILES_OS_UPDATE_OS=${3:-false}
 PLUGINS_DIR=$DOTFILES_ROOT/plugins
 
 # Needs to load the helpers before using it
 source "${DOTFILES_ROOT}/lib/helpers"
-
 
 execute_installers_from_path () {
   install_paths=$1
@@ -21,7 +21,7 @@ execute_installers_from_path () {
   for installer in $install_paths
   do
       info_msg "Installing $installer:"
-      sh -c "$installer"
+      DOTFILES_OS_UPDATE_OS=$DOTFILES_OS_UPDATE_OS sh -c "$installer"
 
       if [[ $? != 0 ]]
       then

--- a/lib/dotfiles-install
+++ b/lib/dotfiles-install
@@ -9,7 +9,6 @@ IFS=$'\n\t'
 
 DOTFILES_ROOT=$1
 DOTFILES_DEBUG=${2:-false}
-DOTFILES_OS_UPDATE_OS=${DOTFILES_OS_UPDATE_OS:-false}
 PLUGINS_DIR=$DOTFILES_ROOT/plugins
 
 # Needs to load the helpers before using it
@@ -21,7 +20,7 @@ execute_installers_from_path () {
   for installer in $install_paths
   do
       info_msg "Installing $installer:"
-      DOTFILES_OS_UPDATE_OS=$DOTFILES_OS_UPDATE_OS sh -c "$installer"
+      DOTFILES_ROOT=$DOTFILES_ROOT DOTFILES_DEBUG=$DOTFILES_DEBUG sh -c "$installer"
 
       if [[ $? != 0 ]]
       then

--- a/lib/dotfiles-install-plugin
+++ b/lib/dotfiles-install-plugin
@@ -25,8 +25,7 @@ export DOTFILES_NO_RELOAD="0"
 
 
 # Checking parameters
-if [ $# -ge 4 ]
-then
+if [[ $# -ne 4 ]]; then
     _show_usage
     exit 1
 fi
@@ -37,11 +36,6 @@ PLUGIN_URL=$4
 PLUGIN_DIR="$DOTFILES_ROOT/plugins"
 PLUGIN=$(basename $PLUGIN_URL | sed 's/.git$//')
 
-# Checking if plugin exists
-if [ -d $PLUGIN_DIR/$PLUGIN ]; then
-    debug_msg "Removing folder $PLUGIN_DIR/$PLUGIN to reinstall"
-    rm -rf $PLUGIN_DIR/$PLUGIN
-fi
 
 # Checking options
 options=$(getopt -l 'help,no-reload' -o 'h::n::' -a -- "$@")
@@ -63,9 +57,16 @@ while true; do
 done
 
 debug_msg "Installing plugin $PLUGIN"
-git clone $PLUGIN_URL "$PLUGIN_DIR/$PLUGIN" -v
-if [[ $? -ne 0 ]]; then
-    fail_msg "Failed to download plugin information"
+
+# Checking if plugin exists
+if [ -d $PLUGIN_DIR/$PLUGIN ]; then
+    info_msg "Plugin already installed. Updating it"
+    cd $PLUGIN_DIR/$PLUGIN && git pull && cd -
+else
+    git clone $PLUGIN_URL "$PLUGIN_DIR/$PLUGIN" -v
+    if [[ $? -ne 0 ]]; then
+        fail_msg "Failed to download plugin information"
+    fi
 fi
 
 make -f $DOTFILES_ROOT/Makefile setup-no-reload

--- a/lib/dotfiles-install-plugin
+++ b/lib/dotfiles-install-plugin
@@ -25,7 +25,7 @@ export DOTFILES_NO_RELOAD="0"
 
 
 # Checking parameters
-if [ $# -ne 4 ]
+if [ $# -ge 4 ]
 then
     _show_usage
     exit 1

--- a/os/install.sh
+++ b/os/install.sh
@@ -64,7 +64,7 @@ update_mac_apps_and_libraries() {
 install_rosetta() {
     if [[ `uname -m` == 'arm64' ]]; then
         blue "[OS] Install Rosetta"
-        sudo /usr/sbin/softwareupdate --install-rosetta --agree-to-license 1>/dev/null
+        sudo /usr/sbin/softwareupdate --install-rosetta --agree-to-license
         green "[OS] Rosetta installed!"
     fi
 }
@@ -86,7 +86,7 @@ then
     cd $HOME
 
     blue "[OS] Install Brew apps defined in the Brewfile (Takes a lot of time first time to install everything)"
-    brew bundle --cleanup --global 1>/dev/null
+    brew bundle --cleanup --global
     green "[OS] Installed!"
 
     blue "[OS] Update all the apps defined in the Brewfile"

--- a/os/install.sh
+++ b/os/install.sh
@@ -20,7 +20,7 @@ install_homebrew() {
         # Install the correct homebrew for each OS type
         if test "$(uname)" = "Darwin"
         then
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+            /bin/bash -c "$(NONINTERACTIVE=1 curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         elif test "$(expr substr $(uname -s) 1 5)" = "Linux"
         then
            ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
@@ -56,7 +56,7 @@ function generate_brewfiles() {
 # yeah, let's do that.
 update_mac_apps_and_libraries() {
     blue "[OS] Update Mac App Store apps"
-    sudo /usr/sbin/softwareupdate -i -r 1>/dev/null
+    sudo /usr/sbin/softwareupdate -i -r
     green "[OS] Updated!"
 }
 
@@ -90,7 +90,7 @@ then
     green "[OS] Installed!"
 
     blue "[OS] Update all the apps defined in the Brewfile"
-    brew update 1>/dev/null
+    brew update
     green "[OS] Updated!"
 
     blue "[OS] Upgrade all the cask apps"

--- a/os/install.sh
+++ b/os/install.sh
@@ -55,9 +55,13 @@ function generate_brewfiles() {
 # command line interface to it that we can use to just install everything, so
 # yeah, let's do that.
 update_mac_apps_and_libraries() {
-    blue "[OS] Update Mac App Store apps"
-    sudo /usr/sbin/softwareupdate -i -r
-    green "[OS] Updated!"
+    if [[ $DOTFILES_OS_UPDATE_OS == "true" ]]; then
+        blue "[OS] Update Mac App Store apps"
+        sudo /usr/sbin/softwareupdate -i -r
+        green "[OS] Updated!"
+    else
+        blue "[OS] Ignored MacOS updated"
+    fi
 }
 
 # Install Rosetta

--- a/os/install.sh
+++ b/os/install.sh
@@ -20,7 +20,7 @@ install_homebrew() {
         # Install the correct homebrew for each OS type
         if test "$(uname)" = "Darwin"
         then
-            /bin/bash -c "$(NONINTERACTIVE=1 curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         elif test "$(expr substr $(uname -s) 1 5)" = "Linux"
         then
            ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"

--- a/os/install.sh
+++ b/os/install.sh
@@ -20,10 +20,10 @@ install_homebrew() {
         # Install the correct homebrew for each OS type
         if test "$(uname)" = "Darwin"
         then
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" 1>/dev/null
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         elif test "$(expr substr $(uname -s) 1 5)" = "Linux"
         then
-           ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)" 1>/dev/null
+           ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
         fi
     else
         green "[OS] Homebrew is already installed"
@@ -42,7 +42,7 @@ function generate_brewfiles() {
     local DESTINATION_FILE="$HOME/.Brewfile"
 
     blue "[OS] Cleanup $DESTINATION_FILE"
-    rm $DESTINATION_FILE
+    rm -f $DESTINATION_FILE
 
     blue "[OS] Search for $SOURCE_FILE inside $SOURCE_FOLDER and generate a merged Brewfile"
     cat $(find -H "$SOURCE_FOLDER" -type f -name "$SOURCE_FILE") >> $DESTINATION_FILE

--- a/os/install.sh
+++ b/os/install.sh
@@ -38,7 +38,7 @@ install_homebrew() {
 # Summary: Search for all SOURCE_FILE inside SOURCE_FOLDER and generates the DESTINATION_FILE
 function generate_brewfiles() {
     local SOURCE_FILE="Brewfile"
-    local SOURCE_FOLDER="$DOTFILES_DIR"
+    local SOURCE_FOLDER="$DOTFILES_ROOT"
     local DESTINATION_FILE="$HOME/.Brewfile"
 
     blue "[OS] Cleanup $DESTINATION_FILE"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -1,9 +1,9 @@
 # shortcut to this dotfiles path is $DOTFILES
-export DOTFILES_DIR=$HOME/.dotfiles
+export DOTFILES_ROOT=$HOME/.dotfiles
 
 # all of our zsh files
 typeset -U config_files
-config_files=($DOTFILES_DIR/**/*.zsh)
+config_files=($DOTFILES_ROOT/**/*.zsh)
 
 # load the path files
 for file in ${(M)config_files:#*/path.zsh}


### PR DESCRIPTION
This PR:

- Fixed the issues hiding messages because the process was not intuitive.
- Added the DOTFILES_OS_UPDATE_OS environment variable to skip the os update as sometimes it hangs up without downloading the complete update so you can have an initial reliable process automated.
- Added environment variables DOTFILES_GIT_AUTHORNAME and DOTFILES_GIT_AUTHOREMAIL to avoid initial git configuration setup on start. If they are not defined it will behave as always.
- Changed the behavior of a plugin update to don't delete the plugin folder to reinstall it, but update it doing a git pull.
  The previous behaviour can lead to unexpected deletion of plugins, so this is safe and if you have local tests in a current plugin you will always preserve it.
- Now the installation of Brew is in NONINTERACTIVE mode, and super user is just requested at beggining of the process, reducing the times you need to introduce your credentials
- Changed internal environment variables for debug that are send to child commands.

