### PR TITLE
Make brew bundle cleanup opt-in and off by default

### DIFF
--- a/os/install.sh
+++ b/os/install.sh
@@ -128,8 +128,22 @@ if test "$(uname)" = "Darwin"; then
     trust_brewfile_taps
 
     blue "[OS] Install Brew apps defined in the Brewfile (Takes a lot of time first time to install everything)"
-    brew bundle --cleanup --global
+    brew bundle --global
     green "[OS] Installed!"
+
+    # Removing apps not listed in the Brewfile is opt-in and off by default, so
+    # an install never uninstalls anything you did not ask it to. Set
+    # DOTFILES_OS_ENABLE_BREW_CLEANUP=true to enable it. The old `brew bundle
+    # --cleanup` switch is deprecated, so this uses the `cleanup` subcommand.
+    # `--force` performs the removal and avoids the exit code 1 that a dry run
+    # returns, which would abort the script under `set -e`.
+    if [[ "${DOTFILES_OS_ENABLE_BREW_CLEANUP:-false}" == "true" ]]; then
+      blue "[OS] Remove Brew apps not listed in the Brewfile"
+      brew bundle cleanup --global --force
+      green "[OS] Removed apps not in the Brewfile!"
+    else
+      blue "[OS] Keep Brew apps not in the Brewfile (set DOTFILES_OS_ENABLE_BREW_CLEANUP=true to remove them)"
+    fi
 
     blue "[OS] Update all the apps defined in the Brewfile"
     brew update


### PR DESCRIPTION
## Problem

Two issues with `brew bundle --cleanup --global` in `os/install.sh`:

1. It uninstalls anything not listed in the Brewfile on every install. That is surprising and can remove tools you installed on purpose.
2. The `--cleanup` switch is deprecated by Homebrew, so it prints a warning on every run.

## Fix

Install now runs plain `brew bundle --global` and never uninstalls by default. Removing apps not in the Brewfile becomes opt-in through `DOTFILES_OS_ENABLE_BREW_CLEANUP` (default false), matching the existing `DOTFILES_OS_ENABLE_DOCTOR` toggle.

When enabled, it uses the modern `brew bundle cleanup --global --force` subcommand, so:

- no deprecation warning
- `--force` performs the removal and avoids the exit code 1 a dry run returns, which would abort `os/install.sh` under `set -e`

Verified with `bash -n`, and the toggle defaults to keeping apps when unset, empty, or false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)